### PR TITLE
Add `import-from-url` command

### DIFF
--- a/pg-tools/Dockerfile
+++ b/pg-tools/Dockerfile
@@ -4,9 +4,10 @@ MAINTAINER tech@texastribune.org
 RUN apt-get update && apt-get install -y \
   curl \
   postgresql-client \
-  pv
+  pv \
+  --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --quiet awscli postdoc
+RUN pip install awscli postdoc
 
 ADD . /app
 

--- a/pg-tools/Dockerfile
+++ b/pg-tools/Dockerfile
@@ -1,7 +1,11 @@
 FROM texastribune/base
 MAINTAINER tech@texastribune.org
 
-RUN apt-get install -yq postgresql-client pv > /dev/null
+RUN apt-get update && apt-get install -y \
+  curl \
+  postgresql-client \
+  pv
+
 RUN pip install --quiet awscli postdoc
 
 ADD . /app

--- a/pg-tools/README.md
+++ b/pg-tools/README.md
@@ -9,8 +9,8 @@ A dockerized toolset for importing and exporting data from a postgreSQL database
 ```
 docker run -it --rm \
   --link=db:db \
-  --env=<aws_access_key_id> \
-  --env=<aws_secret_access_key> \
+  --env=AWS_ACCESS_KEY_ID=<aws_access_key_id> \
+  --env=AWS_SECRET_ACCESS_KEY=<aws_secret_access_key> \
   --env=DATABASE_URL=<database-url> \
   --env=S3_SOURCE=<s3-source> \
   texastribune/pg-tools /app/import-from-s3.sh

--- a/pg-tools/README.md
+++ b/pg-tools/README.md
@@ -1,0 +1,27 @@
+# texastribune/pg-tools
+
+A dockerized toolset for importing and exporting data from a postgreSQL database.
+
+## Example usage
+
+#### Importing from S3
+
+```
+docker run -it --rm \
+  --link=db:db \
+  --env=<aws_access_key_id> \
+  --env=<aws_secret_access_key> \
+  --env=DATABASE_URL=<database-url> \
+  --env=S3_SOURCE=<s3-source> \
+  texastribune/pg-tools /app/import-from-s3.sh
+```
+
+#### Importing from a URL
+
+```
+docker run -it --rm \
+  --link=db:db \
+  --env=DATABASE_URL=<database-url> \
+  --env=DATABASE_BACKUP_URL=<url-to-postgres-dump> \
+  texastribune/pg-tools /app/import-from-url.sh
+```

--- a/pg-tools/import-from-heroku.sh
+++ b/pg-tools/import-from-heroku.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+set -o xtrace
+set -o allexport
+
+readonly filename=/tmp/pg.dump
+
+curl -o ${filename} ${HEROKU_BACKUP_URL}
+
+TEMPLATE_DB=`dirname $DATABASE_URL`/template_db
+
+phd TEMPLATE_DB dropdb --if-exists
+phd TEMPLATE_DB createdb
+phd TEMPLATE_DB pg_restore --no-owner --no-acl --format=custom ${filename}
+
+phd dropdb
+phd createdb --template=template_db

--- a/pg-tools/import-from-s3.sh
+++ b/pg-tools/import-from-s3.sh
@@ -9,7 +9,7 @@ readonly filename=/tmp/pg.dump
 
 aws s3 cp ${S3_SOURCE} ${filename}
 
-TEMPLATE_DB=`dirname $DATABASE_URL`/template_db
+TEMPLATE_DB=$(dirname ${DATABASE_URL})/template_db
 
 phd TEMPLATE_DB dropdb --if-exists
 phd TEMPLATE_DB createdb

--- a/pg-tools/import-from-s3.sh
+++ b/pg-tools/import-from-s3.sh
@@ -4,6 +4,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 set -o xtrace
+set -o allexport
 
 readonly filename=/tmp/pg.dump
 

--- a/pg-tools/import-from-s3.sh
+++ b/pg-tools/import-from-s3.sh
@@ -4,7 +4,6 @@ set -o nounset
 set -o errexit
 set -o pipefail
 set -o xtrace
-set -o allexport
 
 readonly filename=/tmp/pg.dump
 

--- a/pg-tools/import-from-url.sh
+++ b/pg-tools/import-from-url.sh
@@ -8,7 +8,7 @@ set -o allexport
 
 readonly filename=/tmp/pg.dump
 
-curl -o ${filename} ${HEROKU_BACKUP_URL}
+curl -o ${filename} ${DATABASE_BACKUP_URL}
 
 TEMPLATE_DB=`dirname $DATABASE_URL`/template_db
 

--- a/pg-tools/import-from-url.sh
+++ b/pg-tools/import-from-url.sh
@@ -4,6 +4,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 set -o xtrace
+set -o allexport
 
 readonly filename=/tmp/pg.dump
 

--- a/pg-tools/import-from-url.sh
+++ b/pg-tools/import-from-url.sh
@@ -9,7 +9,7 @@ readonly filename=/tmp/pg.dump
 
 curl -o ${filename} ${DATABASE_BACKUP_URL}
 
-TEMPLATE_DB=`dirname $DATABASE_URL`/template_db
+TEMPLATE_DB=$(dirname ${DATABASE_URL})/template_db
 
 phd TEMPLATE_DB dropdb --if-exists
 phd TEMPLATE_DB createdb

--- a/pg-tools/import-from-url.sh
+++ b/pg-tools/import-from-url.sh
@@ -4,7 +4,6 @@ set -o nounset
 set -o errexit
 set -o pipefail
 set -o xtrace
-set -o allexport
 
 readonly filename=/tmp/pg.dump
 


### PR DESCRIPTION
I originally was going down the path of adding an `import-from-heroku` command. But then I realized all it's doing is downloading a `.dump` file from a URL — it doesn't necessarily need to be a Heroku provided URL.

I have some suggested changes to the `Dockerfile` I'd like to discuss. When I was testing this in the beginning, it was breaking because `texastribune/base` isn't up to date. By making it depend on an image further up the change for `apt-get update`, it can lead to mysterious breaks further down the chain.

I suggest we let these images manage their own dependency needs directly.

I also had to add `curl` to the image so downloading from a URL is possible.

Lemme know what you think! 